### PR TITLE
Sync repo to deployed config; switch to journal-only logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`superfan` is a small single-file Python daemon that controls a PWM fan on a Raspberry Pi
+based on CPU temperature. It runs as a systemd service for continuous uptime. It is
+deployed on a host called **loftpi** (`ssh pi@loftpi`).
+
+The entire project is three files:
+
+- `superfan.py` — the daemon (`FanController` class). Depends on `RPi.GPIO`.
+- `superfan.service` — systemd unit.
+- `readme.md` — one-line description.
+
+## How it works (`superfan.py`)
+
+- **PWM**: software PWM on GPIO `FAN_PIN = 14` (BCM) at `PWM_FREQ = 100` Hz via `RPi.GPIO`.
+- **Temperature**: `vcgencmd measure_temp`, parsed from `temp=XX.X'C`. On any error it
+  returns a safe default of `40.0°C`.
+- **Control law**: `TEMP_THRESHOLDS` is an ordered list of `(temp, duty_cycle%, interval_s)`
+  tuples, highest temp first. The loop picks the first row where `temp >= threshold`, sets
+  that duty cycle, then sleeps that interval before re-checking. Hotter = faster fan and
+  more frequent checks. The final `(0, …)` row is the catch-all floor.
+- **Lifecycle**: `SIGTERM`/`SIGINT` set `running = False` for graceful shutdown; sleep is
+  done in 1-second steps so shutdown is responsive. `cleanup()` stops PWM and calls
+  `GPIO.cleanup()`.
+- **Logging**: to both `/var/log/pi-fan-controller.log` and stdout (journal).
+
+Fan behavior is tuned by editing the module-level constants (`FAN_PIN`, `PWM_FREQ`,
+`TEMP_THRESHOLDS`) — there is no CLI/config-file layer.
+
+## Running it
+
+```sh
+sudo python3 superfan.py        # direct run
+sudo systemctl enable --now superfan
+sudo journalctl -u superfan -f  # logs
+```
+
+There is no build step and no test suite. The only third-party dependency is `RPi.GPIO`
+(present on Raspberry Pi OS).
+
+## Known inconsistencies (verify before relying on them)
+
+- `superfan.service` points `ExecStart` at `/usr/local/bin/pi-fan-controller.py`, not at a
+  path matching this repo's `superfan.py`. Deployment must copy/symlink the script to that
+  path (or the unit must be edited). Confirm the actual installed paths on loftpi.
+- `ProtectHome=true` + `ProtectSystem=strict` with `ReadWritePaths=/var/log`: the script
+  must be reachable under those protections and only writes under `/var/log`.

--- a/superfan.py
+++ b/superfan.py
@@ -17,9 +17,9 @@ TEMP_THRESHOLDS = [
     (55, 90, 180),   # temp >= 55°C: 90% speed, check every 3 min
     (50, 80, 120),   # temp >= 50°C: 80% speed, check every 2 min
     (45, 70, 90),    # temp >= 45°C: 70% speed, check every 1.5 min
-    (40, 60, 60),    # temp >= 40°C: 60% speed, check every 1 min
-    (35, 40, 60),    # temp >= 35°C: 40% speed, check every 1 min
-    (0, 25, 60)      # temp < 35°C: 25% speed, check every 1 min
+    (42, 60, 60),    # temp >= 42°C: 60% speed, check every 1 min
+    (40, 40, 60),    # temp >= 40°C: 40% speed, check every 1 min
+    (0, 5, 60)       # temp < 40°C: 5% speed, check every 1 min
 ]
 
 # Setup logging
@@ -27,8 +27,7 @@ logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(levelname)s - %(message)s',
     handlers=[
-        logging.FileHandler('/var/log/pi-fan-controller.log'),
-        logging.StreamHandler(sys.stdout)
+        logging.StreamHandler(sys.stdout)  # -> journald (size-capped); view with journalctl -u superfan
     ]
 )
 

--- a/superfan.service
+++ b/superfan.service
@@ -5,7 +5,7 @@ Wants=multi-user.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/pi-fan-controller.py
+ExecStart=/usr/local/bin/superfan.py
 Restart=always
 RestartSec=10
 User=root
@@ -18,7 +18,6 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true
-ReadWritePaths=/var/log
 
 # Environment
 Environment=PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Summary

The script running on **loftpi** had drifted from this repo. This brings the repo back in line with what's actually deployed, and fixes an unbounded log file on the Pi's storage. Changes have already been deployed and verified on loftpi (service active, journal-only logging confirmed, the old 42 MB log removed).

## Changes

- **`superfan.py` — thresholds:** update `TEMP_THRESHOLDS` to the hand-tuned deployed values (`42`/`40` cutoffs, `60`/`40`/`5`% speeds) and fix the now-stale comments.
- **`superfan.py` — logging:** drop the `FileHandler`; log only to stdout → journald. The flat `/var/log/pi-fan-controller.log` had grown to ~42 MB unrotated and duplicated everything the journal already keeps (and journald is persistent + size-capped here).
- **`superfan.service`:** remove the now-unneeded `ReadWritePaths=/var/log`, and fix `ExecStart` to `/usr/local/bin/superfan.py` (was a stale `pi-fan-controller.py` path that never matched the deployment).
- **`readme.md`:** add the uptime/systemd description line (folded in from the stray `main` branch).
- **`CLAUDE.md`:** repo guidance for future Claude Code sessions.

## On the fan curve (adequacy)

A full year of logs (2025-05-25 → now, ~501k samples) shows:
- **Max CPU temp ever: 64.5°C** — the 100% tier (65°C+) has *never* fired, including last summer in the loft.
- `throttled=0x0` — no throttling ever (Pi throttles at 80°C). ~15–20°C of headroom at worst case.

So the curve is adequate with margin; no speed increase needed.

## Test plan / verification

- [x] Deployed to loftpi, `systemctl restart superfan`, service `active`.
- [x] Confirmed fresh log lines go to `journalctl -u superfan`, no file recreated.
- [x] Old 42 MB log deleted; `df` healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)